### PR TITLE
Add Jest tests for backend routes

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -75,7 +75,11 @@ if(!mongoose.Types.ObjectId.isValid(id)) {
   }
 });
 
-app.listen(5000, () => {
-  connectDB();
-  console.log('Server is running on port 5000');
-});
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(5000, () => {
+    connectDB();
+    console.log('Server is running on port 5000');
+  });
+}
+
+export default app;

--- a/backend/tests/productRoutes.test.js
+++ b/backend/tests/productRoutes.test.js
@@ -1,0 +1,25 @@
+import request from 'supertest';
+import app from '../server.js';
+import Product from '../model/product.model.js';
+
+jest.mock('../model/product.model.js');
+
+describe('POST /api/products', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should create a product when all fields are provided', async () => {
+    const mockProduct = { name: 'Test', price: 10, image: 'img.jpg' };
+    Product.prototype.save.mockResolvedValueOnce(mockProduct);
+
+    const response = await request(app).post('/api/products').send(mockProduct);
+    expect(response.status).toBe(201);
+  });
+
+  it('should return 400 when fields are missing', async () => {
+    const response = await request(app).post('/api/products').send({});
+    expect(response.status).toBe(400);
+  });
+});
+

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+export default {
+  testEnvironment: 'node'
+};
+

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "dev": "nodemon backend/server.js"
+    "dev": "nodemon backend/server.js",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "type": "module",
   "author": "",
@@ -14,5 +15,9 @@
     "express": "^5.1.0",
     "mongoose": "^8.15.1",
     "nodemon": "^3.1.10"
+  },
+  "devDependencies": {
+    "jest": "^29.6.4",
+    "supertest": "^6.3.3"
   }
 }


### PR DESCRIPTION
## Summary
- export the Express app from `server.js`
- add Jest and Supertest dev dependencies
- configure Jest for ES modules
- add initial unit tests for product routes

## Testing
- `npm test` *(fails: Cannot find module '/workspace/MERN-STACK-Product-Store/node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_6849a0f97fd8832fbe01a4c283e382fa